### PR TITLE
Enable read action for cross-platform tests

### DIFF
--- a/prompt.md
+++ b/prompt.md
@@ -4,7 +4,7 @@ You are a universal automation testing assistant that works across Android, iOS,
 # Task
 Your job is to determine the next course of action for the given task across different platforms.
 
-The set of actions available are: tap/click, input, swipe/scroll, wait, error, or finish. Format should be JSON.
+The set of actions available are: tap/click, input, swipe/scroll, read, wait, error, or finish. Format should be JSON.
 
 ## Platform-Specific Action Examples:
 
@@ -12,17 +12,20 @@ The set of actions available are: tap/click, input, swipe/scroll, wait, error, o
 - {"action": "tap", "xpath": "//XCUIElementTypeButton[@name='Info']", "explanation": "Tap Info button using iOS xpath"}
 - {"action": "tap", "bounds": "[8,20][48,64]", "explanation": "Tap Info button using iOS bounds calculated from x,y,width,height"}
 - {"action": "input", "xpath": "//XCUIElementTypeTextField[@name='username']", "value": "testuser", "explanation": "Input text in iOS text field"}
+- {"action": "read", "xpath": "//XCUIElementTypeStaticText[@name='Version']", "explanation": "Read Version label text"}
 
 ### Android Examples:
 - {"action": "tap", "xpath": "//*[@text='Settings']", "explanation": "Tap Settings using Android text attribute"}
 - {"action": "tap", "bounds": "[22,1117][336,1227]", "explanation": "Tap using Android bounds attribute"}
 - {"action": "input", "xpath": "//*[@resource-id='com.app:id/username']", "value": "testuser", "explanation": "Input text using Android resource-id"}
+- {"action": "read", "xpath": "//*[@content-desc='version']", "explanation": "Read version text"}
 
 ### Web Examples:
 - {"action": "tap", "xpath": "//button[text()='Submit']", "explanation": "Click Submit button using web xpath"}
 - {"action": "tap", "css": "#submit-btn", "explanation": "Click Submit button using CSS selector"}
 - {"action": "input", "xpath": "//input[@id='username']", "value": "testuser", "explanation": "Input text in web form field"}
 - {"action": "swipe", "swipe_start_x": 0, "swipe_start_y": 0, "swipe_end_x": 0, "swipe_end_y": -300, "duration": 500, "explanation": "Scroll down on web page"}
+- {"action": "read", "xpath": "//span[@id='version']", "explanation": "Read version text from web page"}
 
 ### Universal Examples:
 - {"action": "wait", "timeout": 5000, "explanation": "Wait for content to load"}

--- a/tasks.json
+++ b/tasks.json
@@ -1,7 +1,12 @@
 [
     {
-        "task": "check version of FortiToken Mobile",
-        "details": "When you use FortiToken Mobile, always check the Version while clicking Info button, recording the steps. When you see version, record the number and stop testing",
+        "task": "Tap Info button",
+        "details": "Tap Info button",
+        "skip": false
+    },
+    {
+        "task": "Read the value of Version",
+        "details": "Read the value of Version",
         "skip": false
     }
 ]


### PR DESCRIPTION
## Summary
- add `read` action handling for web and mobile to capture element text
- update platform instructions and prompt examples to document `read` action
- split sample tasks into tapping Info and reading Version value

## Testing
- `pre-commit run --files ai-testing-tool.py prompt.md tasks.json` *(failed: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f68d527e8832aa8dae3808865f685